### PR TITLE
Add ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,7 @@
         "functions": "never"
       }
     ],
+    "no-console": ["error", { "allow": ["error"] }],
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "import/extensions": [
@@ -58,6 +59,7 @@
       }
     ],
     "import/prefer-default-export": "off",
+    "@typescript-eslint/consistent-type-imports": ["error", { "prefer": "type-imports" }],
     "@typescript-eslint/member-delimiter-style": "error",
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/semi": "error",

--- a/src/@types/react-i18next.d.ts
+++ b/src/@types/react-i18next.d.ts
@@ -1,5 +1,5 @@
 import 'react-i18next';
-import common from '../../public/locales/en/common.json';
+import type common from '../../public/locales/en/common.json';
 
 declare module 'react-i18next' {
   interface CustomTypeOptions {

--- a/src/components/atoms/Footer/Footer.stories.tsx
+++ b/src/components/atoms/Footer/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Footer } from '.';
 

--- a/src/components/molecules/Container/Container.stories.tsx
+++ b/src/components/molecules/Container/Container.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { Container } from '.';
 


### PR DESCRIPTION
Enforce type imports

Don't show warning for `console.error`