### PR TITLE
Change ESLint `no-console` rule level to `warn`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
         "functions": "never"
       }
     ],
-    "no-console": ["error", { "allow": ["error"] }],
+    "no-console": ["warn", { "allow": ["error"] }],
     "object-curly-newline": "off",
     "operator-linebreak": "off",
     "import/extensions": [


### PR DESCRIPTION
It is too strict to cause errors because there is a need to use other console methods for debugging.