### PR TITLE
Change `baseUrl` in `tsconfig` and use path alias

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -76,9 +76,7 @@
   },
   "settings": {
     "import/resolver": {
-      "node": {
-        "paths": ["src"]
-      }
+      "typescript": {}
     }
   }
 }

--- a/__tests__/components/atoms/Footer.test.tsx
+++ b/__tests__/components/atoms/Footer.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { Footer } from 'components/atoms';
+import { Footer } from '~/components/atoms';
 
 it('renders Footer unchanged', () => {
   const { asFragment } = render(<Footer>Main contents</Footer>);

--- a/__tests__/components/molecules/Container.test.tsx
+++ b/__tests__/components/molecules/Container.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { Container } from 'components/molecules';
+import { Container } from '~/components/molecules';
 
 it('renders Container unchanged', () => {
   const { asFragment } = render(<Container>Main contents</Container>);

--- a/__tests__/components/templates/Home.test.tsx
+++ b/__tests__/components/templates/Home.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { Home } from 'components/templates';
+import { Home } from '~/components/templates';
 
 describe('Home', () => {
   it('renders unchanged', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,10 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
-  moduleDirectories: ['node_modules', '<rootDir>/src'],
+  moduleDirectories: ['node_modules', '<rootDir>/'],
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/src/$1',
+  },
   testEnvironment: 'jest-environment-jsdom',
 };
 

--- a/src/@types/react-i18next.d.ts
+++ b/src/@types/react-i18next.d.ts
@@ -1,5 +1,5 @@
 import 'react-i18next';
-import type common from '../../public/locales/en/common.json';
+import type common from 'public/locales/en/common.json';
 
 declare module 'react-i18next' {
   interface CustomTypeOptions {

--- a/src/components/molecules/Container/Container.tsx
+++ b/src/components/molecules/Container/Container.tsx
@@ -1,6 +1,6 @@
 import { Box, Container } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
-import { Footer } from 'components/atoms';
+import { Footer } from '~/components/atoms';
 
 type Props = {
   children: React.ReactNode;

--- a/src/components/templates/Home/Home.tsx
+++ b/src/components/templates/Home/Home.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@chakra-ui/react';
 import { useTranslation } from 'next-i18next';
 import NextLink from 'next/link';
-import { Container } from 'components/molecules';
+import { Container } from '~/components/molecules';
 
 export const Home: React.FC = () => {
   const { t } = useTranslation();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import type { GetStaticProps, NextPage } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import type { Namespace } from 'react-i18next';
-import { Home } from 'components/templates';
+import { Home } from '~/components/templates';
 
 const HomePage: NextPage = () => <Home />;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,10 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": "src"
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "include": ["next-env.d.ts", "next.config.js", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
The `baseUrl` was set to `src` and it was inconvenient to specify the directory from the root like `public`.
Changed the way to specify paths to enhance writability.

- Updated the `baseUrl` to `.` (root directory) and set a path alias for `src` as `~`.
- Updated imports that are relevant.