### PR TITLE
Create `.env` file in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Create .env file
+        run: echo "${{ secrets.ENV_VARS }}" > .env
+
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## What?

The build command in CI now uses `.env` file to load environment variables.

## Why?

`yarn build` fails if some environment variable cannot be found.

## How?

Set the repo secret of environment variables and call it in `ci.yml`.
