### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
 
   lint:
     needs: setup-env
+
+    name: Lint
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -67,7 +71,11 @@ jobs:
 
   test:
     needs: setup-env
+
+    name: Test
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -90,7 +98,11 @@ jobs:
 
   build:
     needs: setup-env
+
+    name: Build
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,36 +11,74 @@ env:
   NODE_VERSION: 17
 
 jobs:
-  lint:
+  setup-env:
+    name: Setup environment
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        id: node-modules-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
+
       - name: Install deps
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn
+
+      - name: Cache node_modules
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
+
+  lint:
+    needs: setup-env
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
 
       - name: Lint
         run: yarn lint
 
   test:
+    needs: setup-env
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
+      - name: Restore node_modules
+        uses: actions/cache@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install deps
-        run: yarn
+          path: node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
 
       - name: Test & publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
@@ -51,21 +89,22 @@ jobs:
           debug: true
 
   build:
+    needs: setup-env
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Restore node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
 
       - name: Create .env file
         run: echo "${{ secrets.ENV_VARS }}" > .env
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install deps
-        run: yarn
 
       - name: Build
         run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,10 @@ name: Lint, test and build
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'src/**'
+      - '__tests__/**'
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - 'src/**'
       - '__tests__/**'
 
+env:
+  NODE_VERSION: 17
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 17
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install deps
         run: yarn
@@ -34,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 17
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install deps
         run: yarn
@@ -59,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 17
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install deps
         run: yarn


### PR DESCRIPTION
## What?

- Trigger CI only when TS or test files are updated
- Cache `node_modules` in CI
- Use `env` for the node version in CI
- Add names for jobs

## Why?

To run CI only when necessary and improve performance and readability.

## How?

- Set `paths` for push trigger
- Use [`actions/cache`](https://github.com/actions/cache) to cache `node_modules`
