### PR TITLE
Update GraphCMS asset URL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,6 @@ module.exports = {
   reactStrictMode: true,
   i18n,
   images: {
-    domains: ['media.graphcms.com'],
+    domains: ['media.graphassets.com'],
   },
 };


### PR DESCRIPTION
## What?

Update domain specification for GraphCMS assets.

## Why?

GraphCMS asset domain has changed.

:eyes: [Notion – The all-in-one workspace for your notes, tasks, wikis, and databases.](https://graphcms.notion.site/Our-Asset-Domain-Will-Change-Soon-9c48046b53cf4d1e9be81135d235ab5f)

## How?

Specify new domain `media.graphassets.com` for `images.domains` in `next.config.js`.

