### PR TITLE
Add CI trigger paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
       - '.github/workflows/ci.yml'
       - 'src/**'
       - '__tests__/**'
+      - 'tsconfig.json'
+      - '.eslintrc.json'
+      - 'jest.setup.js'
+      - 'jest.config.js'
+      - 'next.config.js'
+      - 'yarn.lock'
 
 env:
   NODE_VERSION: 17


### PR DESCRIPTION
## What?

Trigger CI when setting files are updated.

## Why?

CI should run when setting files about linting, testing or building are changed.

## How?

Add paths to `on.push.paths` in CI.

