### PR TITLE
Add game details page

### DIFF
--- a/__tests__/components/atoms/__snapshots__/GameListItem.test.tsx.snap
+++ b/__tests__/components/atoms/__snapshots__/GameListItem.test.tsx.snap
@@ -3,16 +3,17 @@
 exports[`renders GameListItem unchanged 1`] = `
 <DocumentFragment>
   <div
-    class="css-gg4vpm"
+    class="chakra-linkbox css-1cnlftd"
   >
     <div
       class="css-2rlxtj"
     >
-      <p
-        class="chakra-text css-1n49pl7"
+      <a
+        class="chakra-linkbox__overlay css-15i5kzd"
+        href="/games/game"
       >
         Game name
-      </p>
+      </a>
       <p
         class="chakra-text css-0"
       >

--- a/__tests__/components/molecules/BreadcrumbNav.test.tsx
+++ b/__tests__/components/molecules/BreadcrumbNav.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { items } from 'dummies/breadcrumbItems';
+import { BreadcrumbNav } from '~/components/molecules';
+
+it('renders BreadcrumbNav unchanged', () => {
+  const { asFragment } = render(<BreadcrumbNav items={items} />);
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/__tests__/components/molecules/__snapshots__/BreadcrumbNav.test.tsx.snap
+++ b/__tests__/components/molecules/__snapshots__/BreadcrumbNav.test.tsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders BreadcrumbNav unchanged 1`] = `
+<DocumentFragment>
+  <nav
+    aria-label="breadcrumb"
+    class="chakra-breadcrumb css-0"
+  >
+    <ol
+      class="chakra-breadcrumb__list css-0"
+    >
+      <li
+        class="chakra-breadcrumb__list-item css-vn2883"
+      >
+        <a
+          class="chakra-breadcrumb__link css-0"
+          href="/"
+        >
+          Home
+        </a>
+        <span
+          class="css-t4q1nq"
+          role="presentation"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="ChevronRightIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+            />
+          </svg>
+        </span>
+      </li>
+      <li
+        class="chakra-breadcrumb__list-item css-vn2883"
+      >
+        <a
+          class="chakra-breadcrumb__link css-0"
+          href="/docs"
+        >
+          Docs
+        </a>
+        <span
+          class="css-t4q1nq"
+          role="presentation"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="ChevronRightIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+            />
+          </svg>
+        </span>
+      </li>
+      <li
+        class="chakra-breadcrumb__list-item css-vn2883"
+      >
+        <span
+          aria-current="page"
+          class="chakra-breadcrumb__link css-0"
+        >
+          Breadcrumb
+        </span>
+      </li>
+    </ol>
+  </nav>
+</DocumentFragment>
+`;

--- a/__tests__/components/molecules/__snapshots__/GameList.test.tsx.snap
+++ b/__tests__/components/molecules/__snapshots__/GameList.test.tsx.snap
@@ -6,16 +6,17 @@ exports[`renders GameList unchanged 1`] = `
     class="chakra-stack css-1clhiew"
   >
     <div
-      class="css-gg4vpm"
+      class="chakra-linkbox css-1cnlftd"
     >
       <div
         class="css-2rlxtj"
       >
-        <p
-          class="chakra-text css-1n49pl7"
+        <a
+          class="chakra-linkbox__overlay css-15i5kzd"
+          href="/games/first-game"
         >
           First game
-        </p>
+        </a>
         <p
           class="chakra-text css-0"
         >
@@ -45,16 +46,17 @@ exports[`renders GameList unchanged 1`] = `
       </span>
     </div>
     <div
-      class="css-gg4vpm"
+      class="chakra-linkbox css-1cnlftd"
     >
       <div
         class="css-2rlxtj"
       >
-        <p
-          class="chakra-text css-1n49pl7"
+        <a
+          class="chakra-linkbox__overlay css-15i5kzd"
+          href="/games/second-game"
         >
           Second game
-        </p>
+        </a>
         <p
           class="chakra-text css-0"
         >

--- a/__tests__/components/organisms/GameDetails.test.tsx
+++ b/__tests__/components/organisms/GameDetails.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { game } from 'dummies/game';
+import { GameDetails } from '~/components/organisms';
+
+it('renders GameDetails unchanged', () => {
+  const { asFragment } = render(<GameDetails game={game} />);
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/__tests__/components/organisms/__snapshots__/GameDetails.test.tsx.snap
+++ b/__tests__/components/organisms/__snapshots__/GameDetails.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders GameDetails unchanged 1`] = `
+<DocumentFragment>
+  <div
+    class="chakra-stack css-1vpxlgj"
+  >
+    <span
+      style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+    >
+      <span
+        style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+      >
+        <img
+          alt=""
+          aria-hidden="true"
+          src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+          style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+        />
+      </span>
+      <img
+        alt="Game name"
+        data-nimg="intrinsic"
+        decoding="async"
+        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+      />
+      <noscript />
+    </span>
+    <p
+      class="chakra-text css-1n49pl7"
+    >
+      Game name
+    </p>
+    <p
+      class="chakra-text css-0"
+    >
+      Game desciption. This part may contains the description about the game or/and pieces used in the game.
+    </p>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/components/templates/Game.test.tsx
+++ b/__tests__/components/templates/Game.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { game } from 'dummies/game';
+import { Game } from '~/components/templates';
+
+describe('Game', () => {
+  it('renders unchanged', () => {
+    const { asFragment } = render(<Game game={game} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('contains copy right', () => {
+    render(<Game game={game} />);
+    const copyRightElement = screen.getByText(/©/);
+    expect(copyRightElement).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/templates/__snapshots__/Game.test.tsx.snap
+++ b/__tests__/components/templates/__snapshots__/Game.test.tsx.snap
@@ -1,0 +1,154 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Game renders unchanged 1`] = `
+<DocumentFragment>
+  <div
+    class="chakra-container css-1y4v3tz"
+  >
+    <main
+      class="css-i9gxme"
+    >
+      <div
+        class="chakra-stack css-p27qbx"
+      >
+        <nav
+          aria-label="breadcrumb"
+          class="chakra-breadcrumb css-0"
+        >
+          <ol
+            class="chakra-breadcrumb__list css-0"
+          >
+            <li
+              class="chakra-breadcrumb__list-item css-vn2883"
+            >
+              <a
+                class="chakra-breadcrumb__link css-0"
+                href="/games"
+              >
+                games
+              </a>
+              <span
+                class="css-t4q1nq"
+                role="presentation"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="ChevronRightIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+                  />
+                </svg>
+              </span>
+            </li>
+            <li
+              class="chakra-breadcrumb__list-item css-vn2883"
+            >
+              <span
+                aria-current="page"
+                class="chakra-breadcrumb__link css-0"
+              >
+                Game name
+              </span>
+            </li>
+          </ol>
+        </nav>
+        <div
+          class="chakra-stack css-snbr68"
+        >
+          <div
+            class="chakra-stack css-1vpxlgj"
+          >
+            <span
+              style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+            >
+              <span
+                style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjU2IiBoZWlnaHQ9IjI1NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2ZXJzaW9uPSIxLjEiLz4="
+                  style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                />
+              </span>
+              <img
+                alt="Game name"
+                data-nimg="intrinsic"
+                decoding="async"
+                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+              />
+              <noscript />
+            </span>
+            <p
+              class="chakra-text css-1n49pl7"
+            >
+              Game name
+            </p>
+            <p
+              class="chakra-text css-0"
+            >
+              Game desciption. This part may contains the description about the game or/and pieces used in the game.
+            </p>
+          </div>
+          <div
+            class="chakra-stack css-p27qbx"
+          >
+            <button
+              class="chakra-button css-5c2176"
+              type="button"
+            >
+              <span
+                class="chakra-button__icon css-1wh2kri"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="LanguageIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm6.93 6h-2.95c-.32-1.25-.78-2.45-1.38-3.56 1.84.63 3.37 1.91 4.33 3.56zM12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96zM4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2H4.26zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56-1.84-.63-3.37-1.9-4.33-3.56zm2.95-8H5.08c.96-1.66 2.49-2.93 4.33-3.56C8.81 5.55 8.35 6.75 8.03 8zM12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96zM14.34 14H9.66c-.09-.66-.16-1.32-.16-2 0-.68.07-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2zm.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95c-.96 1.65-2.49 2.93-4.33 3.56zM16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2h-3.38z"
+                  />
+                </svg>
+              </span>
+              play-public
+            </button>
+            <button
+              class="chakra-button css-5c2176"
+              type="button"
+            >
+              <span
+                class="chakra-button__icon css-1wh2kri"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+                  data-testid="LockIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
+                  />
+                </svg>
+              </span>
+              play-private
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+    <div
+      class="css-gmuwbf"
+    >
+      © 2022-22 midorimici
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/__tests__/components/templates/__snapshots__/Games.test.tsx.snap
+++ b/__tests__/components/templates/__snapshots__/Games.test.tsx.snap
@@ -17,16 +17,17 @@ exports[`Games renders unchanged 1`] = `
         class="chakra-stack css-1clhiew"
       >
         <div
-          class="css-gg4vpm"
+          class="chakra-linkbox css-1cnlftd"
         >
           <div
             class="css-2rlxtj"
           >
-            <p
-              class="chakra-text css-1n49pl7"
+            <a
+              class="chakra-linkbox__overlay css-15i5kzd"
+              href="/games/first-game"
             >
               First game
-            </p>
+            </a>
             <p
               class="chakra-text css-0"
             >
@@ -56,16 +57,17 @@ exports[`Games renders unchanged 1`] = `
           </span>
         </div>
         <div
-          class="css-gg4vpm"
+          class="chakra-linkbox css-1cnlftd"
         >
           <div
             class="css-2rlxtj"
           >
-            <p
-              class="chakra-text css-1n49pl7"
+            <a
+              class="chakra-linkbox__overlay css-15i5kzd"
+              href="/games/second-game"
             >
               Second game
-            </p>
+            </a>
             <p
               class="chakra-text css-0"
             >

--- a/dummies/breadcrumbItems.ts
+++ b/dummies/breadcrumbItems.ts
@@ -1,0 +1,14 @@
+export const items = [
+  {
+    name: 'Home',
+    path: '/',
+  },
+  {
+    name: 'Docs',
+    path: '/docs',
+  },
+  {
+    name: 'Breadcrumb',
+    path: '/docs/breadcrumb',
+  },
+];

--- a/dummies/game.ts
+++ b/dummies/game.ts
@@ -1,5 +1,5 @@
-export const game = {
-  id: '1234567890abcdef',
+export const game: Game = {
+  slug: 'game',
   name: 'Game name',
   description:
     'Game desciption. This part may contains the description about the game or/and pieces used in the game.',

--- a/dummies/games.ts
+++ b/dummies/games.ts
@@ -1,22 +1,22 @@
-export const games = [
+export const games: Game[] = [
   {
-    id: '1234567890abcdef',
+    slug: 'first-game',
     name: 'First game',
     description:
       'Game desciption. This part may contains the description about the game or/and pieces used in the game.',
     initialBoardImage: {
-      url: 'https://media.graphcms.com/zzxpvUPeT1yHQAO8vSrI',
+      url: 'https://media.graphassets.com/zzxpvUPeT1yHQAO8vSrI',
       width: 256,
       height: 256,
     },
   },
   {
-    id: '1234567890abcde0',
+    slug: 'second-game',
     name: 'Second game',
     description:
       'Game desciption. This part may contains the description about the game or/and pieces used in the game.',
     initialBoardImage: {
-      url: 'https://media.graphcms.com/zzxpvUPeT1yHQAO8vSrI',
+      url: 'https://media.graphassets.com/zzxpvUPeT1yHQAO8vSrI',
       width: 256,
       height: 256,
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@chakra-ui/react": "^1.7.4",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
+    "@mui/icons-material": "^5.6.2",
+    "@mui/material": "^5.6.4",
     "firebase": "^9.6.3",
     "framer-motion": "^5",
     "graphql": "^16.2.0",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,1 +1,1 @@
-{"games":"Games","midorimici":"Midori Mici"}
+{"games":"Games","midorimici":"Midori Mici","play-private":"Play in a private room","play-public":"Play in a public room"}

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -1,1 +1,1 @@
-{"games":"ゲーム","midorimici":"みどりみち"}
+{"games":"ゲーム","midorimici":"みどりみち","play-private":"プライベートルームで遊ぶ","play-public":"パブリックルームで遊ぶ"}

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -1,5 +1,5 @@
 type Game = {
-  id: string;
+  slug: string;
   name: string;
   description: string;
   initialBoardImage: {

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -12,3 +12,7 @@ type Game = {
 type GamesResponse = {
   games: Game[];
 };
+
+type GameResponse = {
+  game: Game;
+};

--- a/src/components/atoms/GameListItem/GameListItem.tsx
+++ b/src/components/atoms/GameListItem/GameListItem.tsx
@@ -1,5 +1,6 @@
-import { Box, Flex, Text } from '@chakra-ui/react';
+import { Box, LinkBox, LinkOverlay, Text } from '@chakra-ui/react';
 import Image from 'next/image';
+import NextLink from 'next/link';
 
 type Props = {
   game: Game;
@@ -9,12 +10,24 @@ export const GameListItem: React.FC<Props> = ({ game }) => {
   const boardImage = game.initialBoardImage;
 
   return (
-    <Flex justifyContent="space-between">
+    <LinkBox
+      display="flex"
+      justifyContent="space-between"
+      borderWidth={1}
+      rounded="md"
+      overflow="hidden"
+      transitionDuration=".2s"
+      _hover={{ bgColor: 'gray.50' }}
+    >
       <Box p={4}>
-        <Text fontSize="2xl">{game.name}</Text>
+        <NextLink href={`/games/${game.slug}`} passHref>
+          <LinkOverlay fontSize="2xl" _before={{ zIndex: 1 }}>
+            {game.name}
+          </LinkOverlay>
+        </NextLink>
         <Text>{game.description}</Text>
       </Box>
       <Image src={boardImage.url} width={boardImage.width} height={boardImage.height} />
-    </Flex>
+    </LinkBox>
   );
 };

--- a/src/components/molecules/BreadcrumbNav/BreadcrumbNav.stories.tsx
+++ b/src/components/molecules/BreadcrumbNav/BreadcrumbNav.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { BreadcrumbNav } from '.';
+import { items } from 'dummies/breadcrumbItems';
+
+const Meta: ComponentMeta<typeof BreadcrumbNav> = {
+  title: 'Molecules/BreadcrumbNav',
+  component: BreadcrumbNav,
+};
+
+export default Meta;
+
+const Template: ComponentStory<typeof BreadcrumbNav> = (args) => <BreadcrumbNav {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  items,
+};

--- a/src/components/molecules/BreadcrumbNav/BreadcrumbNav.tsx
+++ b/src/components/molecules/BreadcrumbNav/BreadcrumbNav.tsx
@@ -1,0 +1,32 @@
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '@chakra-ui/react';
+import ChevronRight from '@mui/icons-material/ChevronRight';
+import NextLink from 'next/link';
+
+type Item = {
+  name: string;
+  path: string;
+};
+
+type Props = {
+  items: Item[];
+};
+
+export const BreadcrumbNav: React.FC<Props> = ({ items }) => (
+  <Breadcrumb separator={<ChevronRight />}>
+    {items.map((item: Item, index: number) => {
+      const isCurrentPage = index === items.length - 1;
+
+      return (
+        <BreadcrumbItem key={item.path} isCurrentPage={isCurrentPage} alignItems="flex-start">
+          {isCurrentPage ? (
+            <BreadcrumbLink href={item.path}>{item.name}</BreadcrumbLink>
+          ) : (
+            <NextLink href={item.path} passHref>
+              <BreadcrumbLink>{item.name}</BreadcrumbLink>
+            </NextLink>
+          )}
+        </BreadcrumbItem>
+      );
+    })}
+  </Breadcrumb>
+);

--- a/src/components/molecules/BreadcrumbNav/index.ts
+++ b/src/components/molecules/BreadcrumbNav/index.ts
@@ -1,0 +1,1 @@
+export { BreadcrumbNav } from './BreadcrumbNav';

--- a/src/components/molecules/GameList/GameList.tsx
+++ b/src/components/molecules/GameList/GameList.tsx
@@ -8,7 +8,7 @@ type Props = {
 export const GameList: React.FC<Props> = ({ games }) => (
   <Stack spacing={8}>
     {games.map((game: Game) => (
-      <GameListItem key={game.id} game={game} />
+      <GameListItem key={game.slug} game={game} />
     ))}
   </Stack>
 );

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,2 +1,3 @@
+export { BreadcrumbNav } from './BreadcrumbNav';
 export { Container } from './Container';
 export { GameList } from './GameList';

--- a/src/components/organisms/GameDetails/GameDetails.stories.tsx
+++ b/src/components/organisms/GameDetails/GameDetails.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { GameDetails } from '.';
+import { game } from 'dummies/game';
+
+const Meta: ComponentMeta<typeof GameDetails> = {
+  title: 'Organisms/GameDetails',
+  component: GameDetails,
+};
+
+export default Meta;
+
+const Template: ComponentStory<typeof GameDetails> = (args) => <GameDetails {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  game,
+};

--- a/src/components/organisms/GameDetails/GameDetails.tsx
+++ b/src/components/organisms/GameDetails/GameDetails.tsx
@@ -1,0 +1,19 @@
+import { Text, VStack } from '@chakra-ui/react';
+import Image from 'next/image';
+
+type Props = {
+  game: Game;
+};
+
+export const GameDetails: React.FC<Props> = ({ game }) => (
+  <VStack alignItems="flex-start" gap={2} flexGrow={1}>
+    <Image
+      src={game.initialBoardImage.url}
+      alt={game.name}
+      width={game.initialBoardImage.width}
+      height={game.initialBoardImage.height}
+    />
+    <Text fontSize="2xl">{game.name}</Text>
+    <Text>{game.description}</Text>
+  </VStack>
+);

--- a/src/components/organisms/GameDetails/index.ts
+++ b/src/components/organisms/GameDetails/index.ts
@@ -1,0 +1,1 @@
+export { GameDetails } from './GameDetails';

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,0 +1,1 @@
+export { GameDetails } from './GameDetails';

--- a/src/components/templates/Game/Game.stories.tsx
+++ b/src/components/templates/Game/Game.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { Game } from '.';
+import { game } from 'dummies/game';
+
+const Meta: ComponentMeta<typeof Game> = {
+  title: 'Templates/Game',
+  component: Game,
+};
+
+export default Meta;
+
+const Template: ComponentStory<typeof Game> = (args) => <Game {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  game,
+};

--- a/src/components/templates/Game/Game.tsx
+++ b/src/components/templates/Game/Game.tsx
@@ -1,0 +1,39 @@
+import { Button, HStack, VStack } from '@chakra-ui/react';
+import Language from '@mui/icons-material/Language';
+import Lock from '@mui/icons-material/Lock';
+import { BreadcrumbNav, Container } from '~/components/molecules';
+import { GameDetails } from '~/components/organisms';
+
+type Props = {
+  game: Game;
+};
+
+export const Game: React.FC<Props> = ({ game }) => (
+  <Container>
+    <VStack alignItems="stretch" spacing={4}>
+      <BreadcrumbNav
+        items={[
+          {
+            name: 'Games',
+            path: '/games',
+          },
+          {
+            name: game.name,
+            path: '',
+          },
+        ]}
+      />
+      <HStack alignItems="flex-start">
+        <GameDetails game={game} />
+        <VStack alignItems="stretch" spacing={4}>
+          <Button size="lg" leftIcon={<Language />}>
+            Play in a public room
+          </Button>
+          <Button size="lg" leftIcon={<Lock />}>
+            Play in a private room
+          </Button>
+        </VStack>
+      </HStack>
+    </VStack>
+  </Container>
+);

--- a/src/components/templates/Game/Game.tsx
+++ b/src/components/templates/Game/Game.tsx
@@ -1,6 +1,7 @@
 import { Button, HStack, VStack } from '@chakra-ui/react';
 import Language from '@mui/icons-material/Language';
 import Lock from '@mui/icons-material/Lock';
+import { useTranslation } from 'next-i18next';
 import { BreadcrumbNav, Container } from '~/components/molecules';
 import { GameDetails } from '~/components/organisms';
 
@@ -8,32 +9,36 @@ type Props = {
   game: Game;
 };
 
-export const Game: React.FC<Props> = ({ game }) => (
-  <Container>
-    <VStack alignItems="stretch" spacing={4}>
-      <BreadcrumbNav
-        items={[
-          {
-            name: 'Games',
-            path: '/games',
-          },
-          {
-            name: game.name,
-            path: '',
-          },
-        ]}
-      />
-      <HStack alignItems="flex-start">
-        <GameDetails game={game} />
-        <VStack alignItems="stretch" spacing={4}>
-          <Button size="lg" leftIcon={<Language />}>
-            Play in a public room
-          </Button>
-          <Button size="lg" leftIcon={<Lock />}>
-            Play in a private room
-          </Button>
-        </VStack>
-      </HStack>
-    </VStack>
-  </Container>
-);
+export const Game: React.FC<Props> = ({ game }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Container>
+      <VStack alignItems="stretch" spacing={4}>
+        <BreadcrumbNav
+          items={[
+            {
+              name: t('games'),
+              path: '/games',
+            },
+            {
+              name: game.name,
+              path: '',
+            },
+          ]}
+        />
+        <HStack alignItems="flex-start">
+          <GameDetails game={game} />
+          <VStack alignItems="stretch" spacing={4}>
+            <Button size="lg" leftIcon={<Language />}>
+              {t('play-public')}
+            </Button>
+            <Button size="lg" leftIcon={<Lock />}>
+              {t('play-private')}
+            </Button>
+          </VStack>
+        </HStack>
+      </VStack>
+    </Container>
+  );
+};

--- a/src/components/templates/Game/index.ts
+++ b/src/components/templates/Game/index.ts
@@ -1,0 +1,1 @@
+export { Game } from './Game';

--- a/src/components/templates/index.ts
+++ b/src/components/templates/index.ts
@@ -1,2 +1,3 @@
+export { Game } from './Game';
 export { Games } from './Games';
 export { Home } from './Home';

--- a/src/pages/games.tsx
+++ b/src/pages/games.tsx
@@ -18,7 +18,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const data = await fetchGql<GamesResponse>(`
     {
       games {
-        id
+        slug
         name
         description
         initialBoardImage {

--- a/src/pages/games/[slug].tsx
+++ b/src/pages/games/[slug].tsx
@@ -1,0 +1,66 @@
+import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import type { Namespace } from 'react-i18next';
+import { i18n } from 'next-i18next.config';
+import { Game } from '~/components/templates';
+import { fetchGql } from '~/lib/graphcms';
+
+const GamePage: NextPage<GameResponse> = ({ game }) => <Game game={game} />;
+
+export default GamePage;
+
+const namespaces: Namespace = ['common'];
+
+export const getStaticProps: GetStaticProps<{ game: Game }, { slug: string }> = async ({
+  params,
+  locale,
+}) => {
+  if (params === undefined) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const data = await fetchGql<GameResponse>(`
+    {
+      game(where: {slug: "${params.slug}"}) {
+        slug
+        name
+        description
+        initialBoardImage {
+          url
+          width
+          height
+        }
+      }
+    }
+  `);
+
+  return {
+    props: {
+      game: data.game,
+      ...(await serverSideTranslations(locale ?? 'en', namespaces)),
+    },
+  };
+};
+
+export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {
+  const data = await fetchGql<{ games: { slug: string }[] }>(`
+    {
+      games {
+        slug
+      }
+    }
+  `);
+
+  const paths = data.games
+    .map((game: { slug: string }) =>
+      i18n.locales.map((locale: string) => ({ params: { slug: game.slug }, locale }))
+    )
+    .flat();
+
+  return {
+    paths,
+    fallback: false,
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,6 +1105,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.17.2", "@babel/runtime@^7.8.7":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.7", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -1799,6 +1806,13 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.1.tgz#cbd843d409dfaad90f9404e7c0404c55eae8c134"
   integrity sha512-bW1Tos67CZkOURLc0OalnfxtSXQJMrAMV0jZTVGJUPSOd4qgjF3+tTD5CwJM13PHA8cltGW1WGbbvV9NpvUZPw==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+
+"@emotion/is-prop-valid@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz#34ad6e98e871aa6f7a20469b602911b8b11b3a95"
+  integrity sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==
   dependencies:
     "@emotion/memoize" "^0.7.4"
 
@@ -2613,6 +2627,93 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@mui/base@5.0.0-alpha.79":
+  version "5.0.0-alpha.79"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.79.tgz#1994a6382a162b52ec93b66f3c74d193820d2365"
+  integrity sha512-/lZLF027BkiEjM8MIYoeS/FEhTKf+41ePU9SOijMGrCin1Y0Igucw+IHa1fF8HXD7wDbFKqHuso3J1jMG8wyNw==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@emotion/is-prop-valid" "^1.1.2"
+    "@mui/types" "^7.1.3"
+    "@mui/utils" "^5.6.1"
+    "@popperjs/core" "^2.11.5"
+    clsx "^1.1.1"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
+
+"@mui/icons-material@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.6.2.tgz#239c40fc5841dc7c6af7d00e4e988550de170fcd"
+  integrity sha512-9QdI7axKuBAyaGz4mtdi7Uy1j73/thqFmEuxpJHxNC7O8ADEK1Da3t2veK2tgmsXsUlAHcAG63gg+GvWWeQNqQ==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+
+"@mui/material@^5.6.4":
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.6.4.tgz#5c6d6770acaea84d7b1c6492639627baed62f65b"
+  integrity sha512-7TD+u/SExZK2a55w6reX56oPk37gKr/M/XGt156X+m0d9LhzOsW864nkErIX/H8oSkX/6kCimxu1FDsO+gjiVw==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@mui/base" "5.0.0-alpha.79"
+    "@mui/system" "^5.6.4"
+    "@mui/types" "^7.1.3"
+    "@mui/utils" "^5.6.1"
+    "@types/react-transition-group" "^4.4.4"
+    clsx "^1.1.1"
+    csstype "^3.0.11"
+    hoist-non-react-statics "^3.3.2"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
+    react-transition-group "^4.4.2"
+
+"@mui/private-theming@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.6.2.tgz#c42da32f8b9481ba12885176c0168a355727c189"
+  integrity sha512-IbrSfFXfiZdyhRMC2bgGTFtb16RBQ5mccmjeh3MtAERWuepiCK7gkW5D9WhEsfTu6iez+TEjeUKSgmMHlsM2mg==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@mui/utils" "^5.6.1"
+    prop-types "^15.7.2"
+
+"@mui/styled-engine@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.6.1.tgz#e2c859a4dbdd65af89e77703a0725285aef471fd"
+  integrity sha512-jEhH6TBY8jc9S8yVncXmoTYTbATjEu44RMFXj6sIYfKr5NArVwTwRo3JexLL0t3BOAiYM4xsFLgfKEIvB9SAeQ==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@emotion/cache" "^11.7.1"
+    prop-types "^15.7.2"
+
+"@mui/system@^5.6.4":
+  version "5.6.4"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.6.4.tgz#b1c615c70b3573d61a8a56dbaee6700bb9a5ca9b"
+  integrity sha512-7rsWED1wMFMePySJobsBerFZNu7ga580QSi3Zd6sJR8nVj12qD3yIdfvxA70/PxJ/805KbIT0GX7edKI+hpyhA==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@mui/private-theming" "^5.6.2"
+    "@mui/styled-engine" "^5.6.1"
+    "@mui/types" "^7.1.3"
+    "@mui/utils" "^5.6.1"
+    clsx "^1.1.1"
+    csstype "^3.0.11"
+    prop-types "^15.7.2"
+
+"@mui/types@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.1.3.tgz#d7636f3046110bcccc63e6acfd100e2ad9ca712a"
+  integrity sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA==
+
+"@mui/utils@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.6.1.tgz#4ab79a21bd481555d9a588f4b18061b3c28ea5db"
+  integrity sha512-CPrzrkiBusCZBLWu0Sg5MJvR3fKJyK3gKecLVX012LULyqg2U64Oz04BKhfkbtBrPBbSQxM+DWW9B1c9hmV9nQ==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+    "@types/prop-types" "^15.7.4"
+    "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
+
 "@napi-rs/triples@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.3.tgz#76d6d0c3f4d16013c61e45dfca5ff1e6c31ae53c"
@@ -2773,6 +2874,11 @@
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
     source-map "^0.7.3"
+
+"@popperjs/core@^2.11.5":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
+  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
 "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0", "@popperjs/core@^2.9.3":
   version "2.11.2"
@@ -4105,15 +4211,34 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
+"@types/prop-types@^15.7.4":
+  version "15.7.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
+  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
 "@types/qs@^6.9.5":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/react-is@^16.7.1 || ^17.0.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
+  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"
   integrity sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.4.4":
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
+  integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
   dependencies:
     "@types/react" "*"
 
@@ -6353,6 +6478,11 @@ csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.19.tgz#feeb5aae89020bb389e1f63669a5ed490e391caa"
   integrity sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==
 
+csstype@^3.0.11:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.11.tgz#d66700c5eacfac1940deb4e3ee5642792d85cd33"
+  integrity sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==
+
 csstype@^3.0.2, csstype@^3.0.9:
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
@@ -6581,6 +6711,14 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@^1.0.1:
   version "1.3.2"
@@ -8294,7 +8432,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -11861,6 +11999,16 @@ react-textarea-autosize@^8.3.0:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-transition-group@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-use-measure@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## What?

Users can go to game details page `/games/[slug]` from game list page `/games`.

## Why?

so that users can check details about games and play them with play buttons.

## How?

- Use `slug` instead of `id` to display it in path.
- Add components and their Storybook and test files to display game details page, with a breadcrumb, an image, a title, a description of the game, and buttons to let users play the game.

## Screenshots

https://user-images.githubusercontent.com/60635066/167057073-88055eec-9102-49b2-8ffa-4e687fbb6dc1.mp4
