### PR TITLE
Replace `graphcms` to `hygraph` in codes

### DIFF
--- a/src/lib/graphcms.ts
+++ b/src/lib/graphcms.ts
@@ -1,5 +1,0 @@
-import { GraphQLClient } from 'graphql-request';
-
-const graphcms = new GraphQLClient(process.env.GRAPHCMS_URL ?? '');
-
-export const fetchGql = async <T>(query: string) => graphcms.request<T>(query);

--- a/src/lib/hygraph.ts
+++ b/src/lib/hygraph.ts
@@ -1,0 +1,5 @@
+import { GraphQLClient } from 'graphql-request';
+
+const hygraph = new GraphQLClient(process.env.HYGRAPH_URL ?? '');
+
+export const fetchGql = async <T>(query: string) => hygraph.request<T>(query);

--- a/src/pages/games.tsx
+++ b/src/pages/games.tsx
@@ -2,7 +2,7 @@ import type { GetStaticProps, NextPage } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import type { Namespace } from 'react-i18next';
 import { Games } from '~/components/templates';
-import { fetchGql } from '~/lib/graphcms';
+import { fetchGql } from '~/lib/hygraph';
 
 type Props = {
   games: Game[];

--- a/src/pages/games/[slug].tsx
+++ b/src/pages/games/[slug].tsx
@@ -3,7 +3,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import type { Namespace } from 'react-i18next';
 import { i18n } from 'next-i18next.config';
 import { Game } from '~/components/templates';
-import { fetchGql } from '~/lib/graphcms';
+import { fetchGql } from '~/lib/hygraph';
 
 const GamePage: NextPage<GameResponse> = ({ game }) => <Game game={game} />;
 


### PR DESCRIPTION
## What?

Replace `graphcms` to `hygraph` in codes.

## Why?

GraphCMS rebranded to Hygraph.

https://hygraph.com/blog/graphcms-is-now-hygraph

## How?

Replace `graphcms` to `hygraph` in codes.
