### PR TITLE
Add create room page

### DIFF
--- a/.storybook/i18n.js
+++ b/.storybook/i18n.js
@@ -1,7 +1,7 @@
 import { initReactI18next } from 'react-i18next';
 import i18n from 'i18next';
 
-const ns = ['common'];
+const ns = ['common', 'new-room'];
 const supportedLngs = ['en', 'ja'];
 
 i18n.use(initReactI18next).init({

--- a/__tests__/components/organisms/NewRoomForm.test.tsx
+++ b/__tests__/components/organisms/NewRoomForm.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { games } from 'dummies/games';
+import { NewRoomForm } from '~/components/organisms';
+
+it('renders NewRoomForm unchanged', () => {
+  const { asFragment } = render(<NewRoomForm games={games} />);
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/__tests__/components/organisms/__snapshots__/NewRoomForm.test.tsx.snap
+++ b/__tests__/components/organisms/__snapshots__/NewRoomForm.test.tsx.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders NewRoomForm unchanged 1`] = `
+<DocumentFragment>
+  <form>
+    <div
+      class="css-0"
+    >
+      <div
+        class="chakra-stack css-0"
+      >
+        <div
+          class="chakra-form-control css-0"
+          role="group"
+        >
+          <label
+            class="chakra-form__label css-0"
+            for="field-:r0:"
+            id="field-:r0:-label"
+          >
+            game-type
+            <span
+              aria-hidden="true"
+              class="chakra-form__required-indicator css-0"
+              role="presentation"
+            >
+              *
+            </span>
+          </label>
+          <div
+            class="chakra-select__wrapper css-0"
+          >
+            <select
+              aria-describedby="field-:r0:-helptext"
+              aria-required="true"
+              class="chakra-select css-0"
+              id="field-:r0:"
+              required=""
+            >
+              <option
+                selected=""
+                value="first-game"
+              >
+                First game
+              </option>
+              <option
+                value="second-game"
+              >
+                Second game
+              </option>
+            </select>
+            <div
+              class="chakra-select__icon-wrapper css-0"
+            >
+              <svg
+                aria-hidden="true"
+                class="chakra-select__icon"
+                focusable="false"
+                role="presentation"
+                style="width: 1em; height: 1em; color: currentColor;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="chakra-form__helper-text css-0"
+            id="field-:r0:-helptext"
+          >
+            Game desciption. This part may contains the description about the game or/and pieces used in the game.
+          </div>
+        </div>
+        <div
+          class="chakra-form-control css-0"
+          role="group"
+        >
+          <label
+            class="chakra-form__label css-0"
+            for="field-:r1:"
+            id="field-:r1:-label"
+          >
+            room-visibility
+            <span
+              aria-hidden="true"
+              class="chakra-form__required-indicator css-0"
+              role="presentation"
+            >
+              *
+            </span>
+          </label>
+          <div
+            class="chakra-radio-group css-0"
+            role="radiogroup"
+          >
+            <div
+              class="chakra-stack css-0"
+            >
+              <label
+                class="chakra-radio css-0"
+                data-checked=""
+              >
+                <input
+                  aria-required="true"
+                  checked=""
+                  class="chakra-radio__input"
+                  id="radio-:r3:"
+                  name="radio-:r2:"
+                  required=""
+                  style="border: 0px; clip: rect(0px, 0px, 0px, 0px); height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; white-space: nowrap; position: absolute;"
+                  type="radio"
+                  value="public"
+                />
+                <span
+                  aria-hidden="true"
+                  class="chakra-radio__control css-0"
+                  data-checked=""
+                />
+                <span
+                  class="chakra-radio__label css-0"
+                  data-checked=""
+                >
+                  public
+                </span>
+              </label>
+              <label
+                class="chakra-radio css-0"
+              >
+                <input
+                  aria-required="true"
+                  class="chakra-radio__input"
+                  id="radio-:r4:"
+                  name="radio-:r2:"
+                  required=""
+                  style="border: 0px; clip: rect(0px, 0px, 0px, 0px); height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; white-space: nowrap; position: absolute;"
+                  type="radio"
+                  value="private"
+                />
+                <span
+                  aria-hidden="true"
+                  class="chakra-radio__control css-0"
+                />
+                <span
+                  class="chakra-radio__label css-0"
+                >
+                  private
+                </span>
+              </label>
+            </div>
+          </div>
+          <div
+            class="chakra-form__helper-text css-0"
+            id="field-:r1:-helptext"
+          >
+            public-description
+          </div>
+        </div>
+        <button
+          class="chakra-button css-0"
+          type="submit"
+        >
+          create
+        </button>
+      </div>
+      <a
+        href="/games/first-game"
+      >
+        <span
+          style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+        >
+          <span
+            style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+          >
+            <img
+              alt=""
+              aria-hidden="true"
+              src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%27256%27%20height=%27256%27/%3e"
+              style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+            />
+          </span>
+          <img
+            data-nimg="intrinsic"
+            decoding="async"
+            src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+            style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+            title="see-game-details"
+          />
+          <noscript />
+        </span>
+      </a>
+    </div>
+  </form>
+</DocumentFragment>
+`;

--- a/__tests__/components/organisms/useForm.test.ts
+++ b/__tests__/components/organisms/useForm.test.ts
@@ -1,0 +1,51 @@
+import { act, renderHook } from '@testing-library/react';
+import { games, gamesMap } from 'dummies/games';
+import { useForm, type UseFormReturnType } from '~/components/organisms/NewRoomForm/useForm';
+
+let result: { current: UseFormReturnType };
+
+describe('useForm', () => {
+  beforeEach(() => {
+    ({ result } = renderHook(() => useForm(games)));
+  });
+
+  it('returns values correctly at first', () => {
+    const { gamesMap: map, selectedGame, visibility } = result.current;
+
+    expect(map).toStrictEqual(gamesMap);
+    expect(selectedGame).toBe(games[0].slug);
+    expect(visibility).toBe('public');
+  });
+
+  it('updates selectedGame correctly after handleGameChange is called', () => {
+    const { handleGameChange } = result.current;
+    const mockEvent = jest.fn(() => ({
+      target: {
+        value: games[1].slug,
+      },
+    })) as unknown as () => React.ChangeEvent<HTMLSelectElement>;
+
+    act(() => handleGameChange(mockEvent()));
+
+    const { selectedGame } = result.current;
+    expect(selectedGame).toBe(games[1].slug);
+  });
+
+  it('updates visibility correctly after handleVisibilityChange is called with a valid value', () => {
+    const { handleVisibilityChange } = result.current;
+
+    act(() => handleVisibilityChange('private'));
+
+    const { visibility } = result.current;
+    expect(visibility).toBe('private');
+  });
+
+  it('returns visibility correctly after handleVisibilityChange is called with an invalid value', () => {
+    const { handleVisibilityChange } = result.current;
+
+    act(() => handleVisibilityChange('invalid'));
+
+    const { visibility } = result.current;
+    expect(visibility).toBe('public');
+  });
+});

--- a/__tests__/components/templates/NewRoom.test.tsx
+++ b/__tests__/components/templates/NewRoom.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { games } from 'dummies/games';
+import { NewRoom } from '~/components/templates';
+
+describe('NewRoom', () => {
+  it('renders unchanged', () => {
+    const { asFragment } = render(<NewRoom games={games} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('contains copy right', () => {
+    render(<NewRoom games={games} />);
+    const copyRightElement = screen.getByText(/©/);
+    expect(copyRightElement).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/templates/__snapshots__/NewRoom.test.tsx.snap
+++ b/__tests__/components/templates/__snapshots__/NewRoom.test.tsx.snap
@@ -1,0 +1,215 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NewRoom renders unchanged 1`] = `
+<DocumentFragment>
+  <div
+    class="chakra-container css-0"
+  >
+    <main
+      class="css-0"
+    >
+      <h2
+        class="chakra-heading css-0"
+      >
+        create-room
+      </h2>
+      <form>
+        <div
+          class="css-0"
+        >
+          <div
+            class="chakra-stack css-0"
+          >
+            <div
+              class="chakra-form-control css-0"
+              role="group"
+            >
+              <label
+                class="chakra-form__label css-0"
+                for="field-:r0:"
+                id="field-:r0:-label"
+              >
+                game-type
+                <span
+                  aria-hidden="true"
+                  class="chakra-form__required-indicator css-0"
+                  role="presentation"
+                >
+                  *
+                </span>
+              </label>
+              <div
+                class="chakra-select__wrapper css-0"
+              >
+                <select
+                  aria-describedby="field-:r0:-helptext"
+                  aria-required="true"
+                  class="chakra-select css-0"
+                  id="field-:r0:"
+                  required=""
+                >
+                  <option
+                    selected=""
+                    value="first-game"
+                  >
+                    First game
+                  </option>
+                  <option
+                    value="second-game"
+                  >
+                    Second game
+                  </option>
+                </select>
+                <div
+                  class="chakra-select__icon-wrapper css-0"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="chakra-select__icon"
+                    focusable="false"
+                    role="presentation"
+                    style="width: 1em; height: 1em; color: currentColor;"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="chakra-form__helper-text css-0"
+                id="field-:r0:-helptext"
+              >
+                Game desciption. This part may contains the description about the game or/and pieces used in the game.
+              </div>
+            </div>
+            <div
+              class="chakra-form-control css-0"
+              role="group"
+            >
+              <label
+                class="chakra-form__label css-0"
+                for="field-:r1:"
+                id="field-:r1:-label"
+              >
+                room-visibility
+                <span
+                  aria-hidden="true"
+                  class="chakra-form__required-indicator css-0"
+                  role="presentation"
+                >
+                  *
+                </span>
+              </label>
+              <div
+                class="chakra-radio-group css-0"
+                role="radiogroup"
+              >
+                <div
+                  class="chakra-stack css-0"
+                >
+                  <label
+                    class="chakra-radio css-0"
+                    data-checked=""
+                  >
+                    <input
+                      aria-required="true"
+                      checked=""
+                      class="chakra-radio__input"
+                      id="radio-:r3:"
+                      name="radio-:r2:"
+                      required=""
+                      style="border: 0px; clip: rect(0px, 0px, 0px, 0px); height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; white-space: nowrap; position: absolute;"
+                      type="radio"
+                      value="public"
+                    />
+                    <span
+                      aria-hidden="true"
+                      class="chakra-radio__control css-0"
+                      data-checked=""
+                    />
+                    <span
+                      class="chakra-radio__label css-0"
+                      data-checked=""
+                    >
+                      public
+                    </span>
+                  </label>
+                  <label
+                    class="chakra-radio css-0"
+                  >
+                    <input
+                      aria-required="true"
+                      class="chakra-radio__input"
+                      id="radio-:r4:"
+                      name="radio-:r2:"
+                      required=""
+                      style="border: 0px; clip: rect(0px, 0px, 0px, 0px); height: 1px; width: 1px; margin: -1px; padding: 0px; overflow: hidden; white-space: nowrap; position: absolute;"
+                      type="radio"
+                      value="private"
+                    />
+                    <span
+                      aria-hidden="true"
+                      class="chakra-radio__control css-0"
+                    />
+                    <span
+                      class="chakra-radio__label css-0"
+                    >
+                      private
+                    </span>
+                  </label>
+                </div>
+              </div>
+              <div
+                class="chakra-form__helper-text css-0"
+                id="field-:r1:-helptext"
+              >
+                public-description
+              </div>
+            </div>
+            <button
+              class="chakra-button css-0"
+              type="submit"
+            >
+              create
+            </button>
+          </div>
+          <a
+            href="/games/first-game"
+          >
+            <span
+              style="box-sizing: border-box; display: inline-block; overflow: hidden; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; position: relative; max-width: 100%;"
+            >
+              <span
+                style="box-sizing: border-box; display: block; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px; max-width: 100%;"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  src="data:image/svg+xml,%3csvg%20xmlns=%27http://www.w3.org/2000/svg%27%20version=%271.1%27%20width=%27256%27%20height=%27256%27/%3e"
+                  style="display: block; max-width: 100%; background: none; opacity: 1; border: 0px; margin: 0px; padding: 0px;"
+                />
+              </span>
+              <img
+                data-nimg="intrinsic"
+                decoding="async"
+                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+                style="position: absolute; top: 0px; left: 0px; bottom: 0px; right: 0px; box-sizing: border-box; padding: 0px; margin: auto; display: block; width: 0px; height: 0px; min-width: 100%; max-width: 100%; min-height: 100%; max-height: 100%;"
+                title="see-game-details"
+              />
+              <noscript />
+            </span>
+          </a>
+        </div>
+      </form>
+    </main>
+    <div
+      class="css-0"
+    >
+      © 2022-22 midorimici
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/dummies/game.ts
+++ b/dummies/game.ts
@@ -1,4 +1,4 @@
-export const game: Game = {
+export const game: GameDetail = {
   slug: 'game',
   name: 'Game name',
   description:

--- a/dummies/games.ts
+++ b/dummies/games.ts
@@ -22,3 +22,8 @@ export const games: GameSummary[] = [
     },
   },
 ];
+
+export const gamesMap: Record<string, GameSummary> = {
+  'first-game': games[0],
+  'second-game': games[1],
+};

--- a/dummies/games.ts
+++ b/dummies/games.ts
@@ -1,4 +1,4 @@
-export const games: Game[] = [
+export const games: GameSummary[] = [
   {
     slug: 'first-game',
     name: 'First game',

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,1 +1,1 @@
-{"games":"Games","midorimici":"Midori Mici","play-private":"Play in a private room","play-public":"Play in a public room"}
+{"audience":"Audience","create-room":"Create a room","games":"Games","midorimici":"Midori Mici","player":"Player","play-private":"Play in a private room","play-public":"Play in a public room"}

--- a/public/locales/en/new-room.json
+++ b/public/locales/en/new-room.json
@@ -1,0 +1,1 @@
+{"create":"Create","game-type":"Game type","private":"Private","private-description":"Only those who know the URL can enter the room.","public":"Public","public-description":"Everyone who can access the website can easily enter the room.","room-visibility":"Room visibility","see-game-details":"See game details"}

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -1,1 +1,1 @@
-{"games":"ゲーム","midorimici":"みどりみち","play-private":"プライベートルームで遊ぶ","play-public":"パブリックルームで遊ぶ"}
+{"audience":"観客","create-room":"新しい部屋を作る","games":"ゲーム","midorimici":"みどりみち","player":"プレーヤー","play-private":"プライベートルームで遊ぶ","play-public":"パブリックルームで遊ぶ"}

--- a/public/locales/ja/new-room.json
+++ b/public/locales/ja/new-room.json
@@ -1,0 +1,1 @@
+{"create":"作成","game-type":"ゲームの種類","private":"プライベート","private-description":"URLを知っている人だけが入室できます。","public":"パブリック","public-description":"Web サイトにアクセスできる人なら誰でも簡単に入室できます。","room-visibility":"部屋の種類","see-game-details":"ゲームの詳細を見る"}

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -1,4 +1,4 @@
-type Game = {
+type GameSummary = {
   slug: string;
   name: string;
   description: string;
@@ -10,9 +10,11 @@ type Game = {
 };
 
 type GamesResponse = {
-  games: Game[];
+  games: GameSummary[];
 };
 
+type GameDetail = GameSummary;
+
 type GameResponse = {
-  game: Game;
+  game: GameDetail;
 };

--- a/src/@types/api.d.ts
+++ b/src/@types/api.d.ts
@@ -18,3 +18,7 @@ type GameDetail = GameSummary;
 type GameResponse = {
   game: GameDetail;
 };
+
+type NewRoomResponse = {
+  games: GameSummary[];
+};

--- a/src/@types/react-i18next.d.ts
+++ b/src/@types/react-i18next.d.ts
@@ -1,11 +1,13 @@
 import 'react-i18next';
 import type common from 'public/locales/en/common.json';
+import type newRoom from 'public/locales/en/new-room.json';
 
 declare module 'react-i18next' {
   interface CustomTypeOptions {
     defaultNS: 'common';
     resources: {
       common: typeof common;
+      'new-room': typeof newRoom;
     };
   }
 }

--- a/src/components/atoms/GameListItem/GameListItem.tsx
+++ b/src/components/atoms/GameListItem/GameListItem.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import NextLink from 'next/link';
 
 type Props = {
-  game: Game;
+  game: GameSummary;
 };
 
 export const GameListItem: React.FC<Props> = ({ game }) => {

--- a/src/components/molecules/GameList/GameList.tsx
+++ b/src/components/molecules/GameList/GameList.tsx
@@ -2,12 +2,12 @@ import { Stack } from '@chakra-ui/react';
 import { GameListItem } from '~/components/atoms';
 
 type Props = {
-  games: Game[];
+  games: GameSummary[];
 };
 
 export const GameList: React.FC<Props> = ({ games }) => (
   <Stack spacing={8}>
-    {games.map((game: Game) => (
+    {games.map((game: GameSummary) => (
       <GameListItem key={game.slug} game={game} />
     ))}
   </Stack>

--- a/src/components/organisms/GameDetails/GameDetails.tsx
+++ b/src/components/organisms/GameDetails/GameDetails.tsx
@@ -2,7 +2,7 @@ import { Text, VStack } from '@chakra-ui/react';
 import Image from 'next/image';
 
 type Props = {
-  game: Game;
+  game: GameDetail;
 };
 
 export const GameDetails: React.FC<Props> = ({ game }) => (

--- a/src/components/organisms/NewRoomForm/NewRoomForm.stories.tsx
+++ b/src/components/organisms/NewRoomForm/NewRoomForm.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { NewRoomForm } from '.';
+import { games } from 'dummies/games';
+
+const Meta: ComponentMeta<typeof NewRoomForm> = {
+  title: 'Organisms/NewRoomForm',
+  component: NewRoomForm,
+};
+
+export default Meta;
+
+const Template: ComponentStory<typeof NewRoomForm> = (args) => <NewRoomForm {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  games,
+};

--- a/src/components/organisms/NewRoomForm/NewRoomForm.tsx
+++ b/src/components/organisms/NewRoomForm/NewRoomForm.tsx
@@ -1,0 +1,82 @@
+import {
+  Button,
+  Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  HStack,
+  Radio,
+  RadioGroup,
+  Select,
+  VStack,
+} from '@chakra-ui/react';
+import { useTranslation } from 'next-i18next';
+import Image from 'next/image';
+import NextLink from 'next/link';
+import { useForm } from './useForm';
+
+type Props = {
+  games: GameSummary[];
+};
+
+export const NewRoomForm: React.FC<Props> = ({ games }) => {
+  const { t } = useTranslation('new-room');
+
+  const {
+    gamesMap,
+    selectedGame,
+    visibility,
+    handleGameChange,
+    handleVisibilityChange,
+    handleSubmit,
+  } = useForm(games);
+  const gameImage = gamesMap[selectedGame].initialBoardImage;
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Flex gap={8} justify="space-between">
+        <VStack spacing={8} flexGrow={1}>
+          <FormControl isRequired>
+            <FormLabel>{t('game-type')}</FormLabel>
+            <Select defaultValue={games[0].slug} onChange={handleGameChange}>
+              {games.map((game: GameSummary) => (
+                <option key={game.slug} value={game.slug}>
+                  {game.name}
+                </option>
+              ))}
+            </Select>
+            <FormHelperText>{gamesMap[selectedGame].description}</FormHelperText>
+          </FormControl>
+          <FormControl isRequired>
+            <FormLabel>{t('room-visibility')}</FormLabel>
+            <RadioGroup
+              colorScheme="orange"
+              defaultValue="public"
+              onChange={handleVisibilityChange}
+            >
+              <HStack spacing={4}>
+                <Radio value="public">{t('public')}</Radio>
+                <Radio value="private">{t('private')}</Radio>
+              </HStack>
+            </RadioGroup>
+            <FormHelperText>{t(`${visibility}-description`)}</FormHelperText>
+          </FormControl>
+          <Button colorScheme="orange" type="submit">
+            {t('create')}
+          </Button>
+        </VStack>
+        <NextLink href={`/games/${selectedGame}`} passHref>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a>
+            <Image
+              src={gameImage.url}
+              width={gameImage.width}
+              height={gameImage.height}
+              title={t('see-game-details')}
+            />
+          </a>
+        </NextLink>
+      </Flex>
+    </form>
+  );
+};

--- a/src/components/organisms/NewRoomForm/index.ts
+++ b/src/components/organisms/NewRoomForm/index.ts
@@ -1,2 +1,1 @@
 export { NewRoomForm } from './NewRoomForm';
-export { GameDetails } from './GameDetails';

--- a/src/components/organisms/NewRoomForm/useForm.ts
+++ b/src/components/organisms/NewRoomForm/useForm.ts
@@ -1,0 +1,51 @@
+import { useCallback, useMemo, useState } from 'react';
+
+type Visibility = 'public' | 'private';
+
+type UseFormReturnType = {
+  gamesMap: Record<string, GameSummary>;
+  selectedGame: string;
+  visibility: Visibility;
+  handleGameChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleVisibilityChange: (value: string) => void;
+  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+};
+
+export const useForm = (games: GameSummary[]): UseFormReturnType => {
+  const [selectedGame, setSelectedGame] = useState(games[0].slug);
+  const [visibility, setVisibility] = useState<Visibility>('public');
+
+  const gamesMap: Record<string, GameSummary> = useMemo(
+    () => Object.fromEntries(games.map((game: GameSummary) => [game.slug, game])),
+    [games]
+  );
+
+  const handleGameChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedGame(event.target.value);
+  }, []);
+
+  const handleVisibilityChange = useCallback((value: string) => {
+    if (value !== 'public' && value !== 'private') {
+      return;
+    }
+
+    setVisibility(value);
+  }, []);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      console.info(selectedGame, visibility);
+    },
+    [selectedGame, visibility]
+  );
+
+  return {
+    gamesMap,
+    selectedGame,
+    visibility,
+    handleGameChange,
+    handleVisibilityChange,
+    handleSubmit,
+  };
+};

--- a/src/components/organisms/NewRoomForm/useForm.ts
+++ b/src/components/organisms/NewRoomForm/useForm.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 type Visibility = 'public' | 'private';
 
-type UseFormReturnType = {
+export type UseFormReturnType = {
   gamesMap: Record<string, GameSummary>;
   selectedGame: string;
   visibility: Visibility;

--- a/src/components/templates/Game/Game.tsx
+++ b/src/components/templates/Game/Game.tsx
@@ -6,7 +6,7 @@ import { BreadcrumbNav, Container } from '~/components/molecules';
 import { GameDetails } from '~/components/organisms';
 
 type Props = {
-  game: Game;
+  game: GameDetail;
 };
 
 export const Game: React.FC<Props> = ({ game }) => {

--- a/src/components/templates/Games/Games.tsx
+++ b/src/components/templates/Games/Games.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'next-i18next';
 import { Container, GameList } from '~/components/molecules';
 
 type Props = {
-  games: Game[];
+  games: GameSummary[];
 };
 
 export const Games: React.FC<Props> = ({ games }) => {

--- a/src/components/templates/NewRoom/NewRoom.stories.tsx
+++ b/src/components/templates/NewRoom/NewRoom.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { NewRoom } from '.';
+import { games } from 'dummies/games';
+
+const Meta: ComponentMeta<typeof NewRoom> = {
+  title: 'Templates/NewRoom',
+  component: NewRoom,
+};
+
+export default Meta;
+
+const Template: ComponentStory<typeof NewRoom> = (args) => <NewRoom {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  games,
+};

--- a/src/components/templates/NewRoom/NewRoom.tsx
+++ b/src/components/templates/NewRoom/NewRoom.tsx
@@ -1,0 +1,19 @@
+import { Heading } from '@chakra-ui/react';
+import { useTranslation } from 'next-i18next';
+import { Container } from '~/components/molecules';
+import { NewRoomForm } from '~/components/organisms';
+
+type Props = {
+  games: GameSummary[];
+};
+
+export const NewRoom: React.FC<Props> = ({ games }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Container>
+      <Heading mb={4}>{t('create-room')}</Heading>
+      <NewRoomForm games={games} />
+    </Container>
+  );
+};

--- a/src/components/templates/NewRoom/index.ts
+++ b/src/components/templates/NewRoom/index.ts
@@ -1,0 +1,1 @@
+export { NewRoom } from './NewRoom';

--- a/src/components/templates/index.ts
+++ b/src/components/templates/index.ts
@@ -1,3 +1,4 @@
 export { Game } from './Game';
 export { Games } from './Games';
 export { Home } from './Home';
+export { NewRoom } from './NewRoom';

--- a/src/pages/games.tsx
+++ b/src/pages/games.tsx
@@ -5,7 +5,7 @@ import { Games } from '~/components/templates';
 import { fetchGql } from '~/lib/hygraph';
 
 type Props = {
-  games: Game[];
+  games: GameSummary[];
 };
 
 const GamesPage: NextPage<Props> = ({ games }) => <Games games={games} />;
@@ -14,7 +14,9 @@ export default GamesPage;
 
 const namespaces: Namespace = ['common'];
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => {
+export const getStaticProps: GetStaticProps<{ games: GameSummary[] }, { slug: string }> = async ({
+  locale,
+}) => {
   const data = await fetchGql<GamesResponse>(`
     {
       games {

--- a/src/pages/games/[slug].tsx
+++ b/src/pages/games/[slug].tsx
@@ -11,7 +11,7 @@ export default GamePage;
 
 const namespaces: Namespace = ['common'];
 
-export const getStaticProps: GetStaticProps<{ game: Game }, { slug: string }> = async ({
+export const getStaticProps: GetStaticProps<{ game: GameDetail }, { slug: string }> = async ({
   params,
   locale,
 }) => {

--- a/src/pages/new-room.tsx
+++ b/src/pages/new-room.tsx
@@ -1,0 +1,41 @@
+import type { GetStaticProps, NextPage } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import type { Namespace } from 'react-i18next';
+import { NewRoom } from '~/components/templates';
+import { fetchGql } from '~/lib/hygraph';
+
+type Props = {
+  games: GameSummary[];
+};
+
+const NewRoomPage: NextPage<Props> = ({ games }) => <NewRoom games={games} />;
+
+export default NewRoomPage;
+
+const namespaces: Namespace = ['common', 'new-room'];
+
+export const getStaticProps: GetStaticProps<{ games: GameSummary[] }, { slug: string }> = async ({
+  locale,
+}) => {
+  const data = await fetchGql<NewRoomResponse>(`
+    {
+      games {
+        slug
+        name
+        description
+        initialBoardImage {
+          url
+          width
+          height
+        }
+      }
+    }
+  `);
+
+  return {
+    props: {
+      games: data.games,
+      ...(await serverSideTranslations(locale ?? 'en', namespaces)),
+    },
+  };
+};


### PR DESCRIPTION
## What?

Create `/new-room` page.

## Why?

So that users can create a new room to play a game.

## How?

- Add components and their Storybook and test files to display room creation form
- Add hooks to handle room creation form

## Screenshots

https://user-images.githubusercontent.com/60635066/189519849-4b571ba2-a826-4458-96a9-48f820c40c97.mp4
